### PR TITLE
fix: add nodemon as dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "mongoose": "^5.9.23",
     "validator": "^13.5.2"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "nodemon": "^2.0.15"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "nodemon app.js"


### PR DESCRIPTION
Hi, I've added `nodemon` as a dev dependency - I've tried to run the project with `npm run start` but `nodemon` wasn't installed. This pull request fixes that. :)